### PR TITLE
Update WP Browser.jsx

### DIFF
--- a/WP Browser.jsx
+++ b/WP Browser.jsx
@@ -3,6 +3,7 @@
 var WPBrowserApiKey = '';
 var WPBrowserSearchServer = '';
 var WPBrowserSearchEndpoint = '/wp-admin/admin-ajax.php?action=wp-browser-search&apiKey=' + WPBrowserApiKey + '&s=';
+var WPBrowserSearchPort = '80';
 var WPBrowserNotifyServer = WPBrowserSearchServer;
 var WPBrowserNotifyEndpoint = '/wp-admin/admin-ajax.php?action=wp-browser-notify&apiKey=' + WPBrowserApiKey;
 var placeFromServer = true;
@@ -184,7 +185,7 @@ function getURL( server, page ) {
 	conn = new Socket;
 	conn.timeout=30;
 	conn.encoding = 'UTF-8';
-	if( conn.open( server + ':80' ) ) {
+	if( conn.open( server + ':' + WPBrowserSearchPort ) ) {
 		conn.write( 'GET ' + page + ' HTTP/1.0' + "\n\n" );
 		reply = conn.read(999999);
 		conn.close();


### PR DESCRIPTION
added the port to use for the socket connection as a variable. needed this to do, to have a workaround for apache virtual host issues: if the virtual host is not the default configured host for the server, the connection would fail. a workaround is to let apache listen on a special port that only the desired virtual host is listening to.
